### PR TITLE
Upgrade dependencies, minor cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ documentation = "https://docs.rs/stun3489"
 repository = "https://github.com/manuels/stun3489"
 
 [dependencies]
-byteorder = "1.2.7"
-futures = "0.3.4"
-async-std = {version = "1.4.0", features = ["unstable"]}
-rand = "0.6.1"
-log = "0.4.6"
-env_logger = "0.7.1"
-bytes = "0.5.4"
-nix = "0.17.0"
+byteorder = "1.2"
+bytes = "0.5"
+futures = "0.3"
+log = "0.4"
+rand = { version = "0.7", features = ["small_rng"] }
+
+[dev-dependencies]
+async-std = { version = "1.4", features = ["unstable"] }
+env_logger = "0.7"
+nix = "0.17"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -323,7 +323,7 @@ impl Attribute {
                 }
                 assert_eq!(buf.len(), total_len);
 
-                (USERNAME, buf.clone())
+                (USERNAME, buf)
             }
             Attribute::ChangeRequest(ref c) => (CHANGE_REQUEST, Self::encode_change_request(c)?),
             Attribute::UnknownOptional => unreachable!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
-extern crate byteorder;
-extern crate futures;
-extern crate rand;
-//extern crate ring;
-#[macro_use]
-extern crate log;
-extern crate bytes;
-extern crate env_logger;
-
 pub mod codec;
 
 pub use crate::codec::StunCodec;
@@ -15,8 +6,9 @@ use std::io::Error;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 
+use log::{debug, info};
+use rand::SeedableRng;
 use rand::rngs::SmallRng;
-use rand::FromEntropy;
 use rand::Rng;
 
 use futures::prelude::*;


### PR DESCRIPTION
* Use fuzzy version selectors
* Bump `rand` 0.6 => 0.7
* Move test deps to dev-dependencies
* Fix unnecessary clone reported by `cargo clippy`
* Remove `extern crate` defs (not needed in Rust 2018)
* `use` instead of `#[macro_use]`